### PR TITLE
Bugfix

### DIFF
--- a/frontend/src/components/chat/navigation/ChatDropdownMenu.js
+++ b/frontend/src/components/chat/navigation/ChatDropdownMenu.js
@@ -39,7 +39,7 @@ class ChatDropdownMenu extends Component {
         axios.get(config.backendUrl + '/logout')
         .then(res => {
             if (res.status === 200 && res.data === 'Logout OK') {
-                this.context.router.history.push('/');
+                window.location.reload();
             }
         })
         .catch(error => {


### PR DESCRIPTION
On logout, socket connections to realtime/presence remain open when pushing to history using react. Use window reload instead to disconnect.