### PR TITLE
Handle duplicate emails errors gracefully

### DIFF
--- a/backend/unimeet/views.py
+++ b/backend/unimeet/views.py
@@ -7,6 +7,7 @@ import os
 from django.conf import settings
 from models import User
 
+
 with open(os.path.join(os.path.dirname(settings.BASE_DIR), 'config', 'services.json'), 'r') as f:
     service_data = json.load(f)
 

--- a/backend/unimeet/views.py
+++ b/backend/unimeet/views.py
@@ -1,7 +1,7 @@
 from django.http import JsonResponse, HttpResponse, HttpResponseBadRequest, HttpResponseRedirect
 from django.views.decorators.csrf import csrf_exempt
 import json
-from helpers import get_school_list, get_school_by_email, create_user, update_password, handle_contact_form, handle_service_stats
+from helpers import get_school_list, get_school_by_email, create_user, update_password, handle_contact_form, handle_service_stats, DuplicateEmailError
 from django.contrib.auth import authenticate, login as Django_login, logout as Django_logout, update_session_auth_hash
 import os
 from django.conf import settings
@@ -25,6 +25,8 @@ def signup(request):
         try:
             create_user(email, school)
             return HttpResponse('Signup OK')
+        except DuplicateEmailError:
+            return HttpResponse(content='Duplicate email', status=409)
         except ValueError:
             return HttpResponseBadRequest('Invalid email')
     return HttpResponseBadRequest('Invalid univesity email')

--- a/frontend/src/components/common/Topbar.js
+++ b/frontend/src/components/common/Topbar.js
@@ -6,6 +6,10 @@ import logo from './img/unimeetLogo.png';
 import './styles.css';
 
 class Topbar extends Component {
+    forgot() {
+        this.refs.welcometopmenu.forgot();
+    }
+
     render() {
         return (
             <Navbar fixedTop>
@@ -21,7 +25,7 @@ class Topbar extends Component {
                     }
                 </Navbar.Header>
                 {this.props.page === 'welcome' ?
-                    <WelcomeTopMenu /> :
+                    <WelcomeTopMenu ref='welcometopmenu' /> :
                 this.props.page === 'contact' ?
                     null :
                 this.props.page === 'chat' ?

--- a/frontend/src/components/welcome/Welcome.js
+++ b/frontend/src/components/welcome/Welcome.js
@@ -13,6 +13,11 @@ class Welcome extends Component {
         this.state = {
             isLoggedOut: false
         };
+        this.forgot = this.forgot.bind(this);
+    }
+
+    forgot() {
+        this.refs.topbar.forgot();
     }
 
     static get contextTypes() {
@@ -36,8 +41,8 @@ class Welcome extends Component {
             <div className="Welcome">
                 {this.state.isLoggedOut ?
                     <div>
-                        <Topbar page={'welcome'} />
-                        <Intro />
+                        <Topbar page={'welcome'} ref='topbar' />
+                        <Intro onforgot={this.forgot} />
                         <Footer />
                     </div>
                 : ''}

--- a/frontend/src/components/welcome/body/Intro.js
+++ b/frontend/src/components/welcome/body/Intro.js
@@ -3,6 +3,15 @@ import SignupForm from './SignupForm';
 import LoginForm from '../common/LoginForm';
 
 class Intro extends Component {
+    constructor(props) {
+        super(props);
+        this.forgot = this.forgot.bind(this);
+    }
+
+    forgot() {
+        this.props.onforgot();
+    }
+
     render() {
         return (
             <div className="intro-section">
@@ -12,7 +21,7 @@ class Intro extends Component {
                             <div className="container form-container well text-center">
                                 <h4>Μίλα ανώνυμα με άλλους φοιτητές</h4>
                                 <hr/>
-                                <SignupForm />
+                                <SignupForm onforgot={this.forgot} />
                             </div>
                             <div className="container form-container well text-center" id="login-form">
                                 <h4>Σύνδεση</h4>

--- a/frontend/src/components/welcome/body/SignupForm.js
+++ b/frontend/src/components/welcome/body/SignupForm.js
@@ -14,8 +14,10 @@ class SignupForm extends Component {
             email: '',
             isModalOpen: false,
             isSignupButtonLoading: false,
-            invalidEmail: false
+            invalidEmail: false,
+            duplicateEmail: false
         };
+        this.forgot = this.forgot.bind(this);
     }
 
     hideModal = () => {
@@ -24,9 +26,10 @@ class SignupForm extends Component {
 
     handleEmailChange = (event) => {
         this.setState({email: event.target.value});
-        if (this.state.invalidEmail) {
-            this.setState({invalidEmail: false});
-        }
+        this.setState({
+            invalidEmail: false,
+            duplicateEmail: false
+        });
     }
 
     signupSubmit = (event) => {
@@ -46,11 +49,29 @@ class SignupForm extends Component {
         .catch(error => {
             this.setState({
                 isSignupButtonLoading: false,
-                invalidEmail: true
+                duplicateEmail: false,
+                invalidEmail: false
             });
+            switch (error.response.status) {
+                case 409:
+                    this.setState({
+                        duplicateEmail: true
+                    });
+                    break;
+                default:
+                    this.setState({
+                        invalidEmail: true
+                    });
+            };
             this.signupEmail.focus();
             console.log(error);
         })
+    }
+
+    forgot(e) {
+        e.preventDefault();
+
+        this.props.onforgot();
     }
 
     render() {
@@ -86,6 +107,10 @@ class SignupForm extends Component {
                     {this.state.invalidEmail ?
                         <div className="email-error">
                             <b>Υπήρξε κάποιο πρόβλημα! Χρησιμοποίησες ένα <Link to="/faq" target="_blank">έγκυρο ακαδημαϊκό</Link> email?</b>
+                        </div>
+                    : this.state.duplicateEmail ?
+                        <div className="email-error">
+                            <b>Το email που επέλεξες χρησιμοποιείται ήδη! <a onClick={this.forgot} href=''>Επανάφερε τον κωδικό σου</a>.</b>
                         </div>
                     : null}
                 </Form>

--- a/frontend/src/components/welcome/body/SignupForm.js
+++ b/frontend/src/components/welcome/body/SignupForm.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
 import {Form, FormControl, FormGroup, Button} from 'react-bootstrap';
 import SignupModal from './SignupModal';
 import * as config from '../../config';
@@ -63,7 +64,9 @@ class SignupForm extends Component {
                         invalidEmail: true
                     });
             };
-            this.signupEmail.focus();
+            var signupEmailElement = ReactDOM.findDOMNode(this.signupEmail);
+            signupEmailElement.focus();
+            signupEmailElement.select();
             console.log(error);
         })
     }

--- a/frontend/src/components/welcome/common/ForgotPasswordModal.js
+++ b/frontend/src/components/welcome/common/ForgotPasswordModal.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
 import {Modal, Form, FormGroup, FormControl, Button} from 'react-bootstrap';
 import * as config from '../../config';
 
@@ -21,6 +22,8 @@ class ForgotPasswordModal extends Component {
             isForgotPasswordButtonLoading: false,
             isPasswordResetMailSent: false
         });
+        var emailElement = ReactDOM.findDOMNode(this.refs.email);
+        emailElement.focus();
     }
 
 
@@ -72,6 +75,7 @@ class ForgotPasswordModal extends Component {
                                         autoComplete="off"
                                         disabled={this.state.isForgotPasswordButtonLoading}
                                         onChange={this.handleInputChange}
+                                        ref="email"
                                     />
                                 </FormGroup>
                                 <Button

--- a/frontend/src/components/welcome/common/LoginForm.js
+++ b/frontend/src/components/welcome/common/LoginForm.js
@@ -22,6 +22,10 @@ class LoginForm extends Component {
         this.setState({isModalOpen: false});
     }
 
+    forgot = () => {
+        this.showModal();
+    }
+
     showModal = () => {
         this.setState({isModalOpen: true});
     }

--- a/frontend/src/components/welcome/navigation/WelcomeTopMenu.js
+++ b/frontend/src/components/welcome/navigation/WelcomeTopMenu.js
@@ -3,10 +3,14 @@ import {Navbar} from 'react-bootstrap';
 import LoginForm from '../common/LoginForm';
 
 class WelcomeTopMenu extends Component {
+    forgot() {
+        this.refs.loginform.forgot();
+    }
+
     render() {
         return (
             <Navbar.Collapse>
-                <LoginForm />
+                <LoginForm ref='loginform' />
             </Navbar.Collapse>
         );
     }


### PR DESCRIPTION
This patch modifies the RESTful API server to emit a 409 HTTP response on duplicate email. The client displays an appropriate error message.

The convoluted architectural changes required for the client indicate that a migration to [redux](http://redux.js.org/) will significantly clean up the code and make future changes more clean less repetitive. I recommend that we make it an issue to do this.